### PR TITLE
bugfix: use JsonTypeInfo.As.EXISTING_PROPERTY for base object of allOf

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-spring/typeInfoAnnotation.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-spring/typeInfoAnnotation.mustache
@@ -1,6 +1,6 @@
 {{#jackson}}
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminatorName}}}", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "{{{discriminatorName}}}", visible = true)
 @JsonSubTypes(
   {{#discriminator.mappedModels}}
       JsonSubTypes.Type(value = {{modelName}}::class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"){{^-last}},{{/-last}}


### PR DESCRIPTION
The object generated using "allOf" property will produce after serialization a json with multiple discriminator attribute. This is caused by the behaviour of JsonTypeInfo.As.JsonTypeInfo.

We should replace it by EXISTING_PROPERTY
````

/**
         * Inclusion mechanism similar to <code>PROPERTY</code> with respect
         * to deserialization; but one that is produced by a "regular" accessible
         * property during serialization. This means that <code>TypeSerializer</code>
         * will do nothing, and expects a property with defined name to be output
         * using some other mechanism (like default POJO property serialization, or
         * custom serializer).
         *<p>
         * Note that this behavior is quite similar to that of using {@link JsonTypeId}
         * annotation;
         * except that here <code>TypeSerializer</code> is basically suppressed;
         * whereas with {@link JsonTypeId}, output of regular property is suppressed.
         * This mostly matters with respect to output order; this choice is the only
         * way to ensure specific placement of type id during serialization.
         * 
         * @since 2.3.0 but databind <b>only since 2.5.0</b>.
         */
        EXISTING_PROPERTY
```